### PR TITLE
PIP-3: Advanced querying and updates on LinkLanguages

### DIFF
--- a/pip-0003.md
+++ b/pip-0003.md
@@ -1,0 +1,111 @@
+# PIP-3: Advanced querying and updates on LinkLanguages
+
+## Scope
+This PIP aims to create a spec allowing LinkLanguages to signal mutation, and querying of link data via SPARQL methods, with varying levels of compliance with SPARQL abilities.
+
+## Why
+Currently when querying Perspectives/Neighbourhoods its only possible to query via; source, target, predicate with optional to/from date's for filtering. This allows querying at one dimension but does not allow for advanced querying, where you may wish to do something such as getLinks and then load adjacent links associated to found triples to load large data feeds. At Flux, we have already ran into this limitation and have to issue multiple queries to fetch, emojis & replies for each chat link. 
+
+## Useful Resources
+
+SPARQL in 11 minutes: https://www.youtube.com/watch?v=FvGndkpa4K0
+SPARQL cheatsheet: https://www.iro.umontreal.ca/~lapalme/ift6281/sparql-1_1-cheat-sheet.pdf
+
+---
+
+## Implementation
+
+All proposed changes here are to be made on the LinkLanguage Language interface.
+
+### Mutation Operation Changes
+##### Keep:
+```
+addLink(...)
+updateLink(...)
+removeLink(...)
+```
+
+but make optional. So that there is always a simple interface for mutation if a user does not want to use SPARQL?
+
+##### Add:
+
+```
+mutate(command: string)
+```
+
+where command is a SPARQL query string (encoded) making the following possible operations
+
+```
+# REQUIRED SUPPORTED BY LANGUAGE:
+INSERT DATA { triples }
+DELETE DATA { triples }
+
+# OPTIONALLY SUPPORTED BY LANGUAGE:
+[ DELETE { template } ] [ INSERT { template } ] WHERE { pattern }
+LOAD <uri> [ INTO GRAPH <uri> ]
+CLEAR GRAPH <uri>
+CREATAE GRAPH <uri>
+DROP GRAPH <uri>
+```
+
+Note that the above operations also make it possible to insert/delete multiple triples at once, this could make it easy to mass insert data for creating archives of existing data or loading data for testing.
+
+### Query Changes
+
+##### Keep:
+
+`getLinks()` but make optional. So that there is always a simple interface for querying if desired?
+
+##### Add:
+```
+queryLinks(query: string): Promise<Expression[]>;
+```
+
+where command is a SPARQL query string (encoded). It would be expected that the LinkLangauge being queried would be able to respond to any valid SPARQL query where methods used are denoted as supported (see below).
+
+##### SPARQL Literal Support
+
+SPARQL triple values makes uses of literals to denote types, see:
+
+![](https://i.imgur.com/YkjEGdu.png)
+
+Since a `LinkExpression` in AD4M are supposed to reference expression URI's, we may want some kind of mapping between AD4M expression URI's & SPARQL literals, for example: `xsd://integer#3`. Which when resolved in AD4M would return the specification for xsd://integer (likely scrapped from the xsd specification). LinkLanguage storage backends could still leverage existing SPARQL literal structures for performance optimization, but then apply the AD4M formatting once results are retreived and before being returned to language caller.
+
+---
+
+### Optional Additions
+
+The following are some things that came up whilst thinking about this PIP, but may not be directly necassary now, but atleast worth talking about.
+
+#### SPARQL query ability signaling
+Add interface which can return supported SPARQL "methods", looking like:
+
+```
+supportedMethods(): SPARQLMethods
+
+interface SPARQLMethods {
+    modifiers: {methodName: boolean, ...},
+    queryForms: {methodName: boolean, ...},
+    filterEvaluations: {methodName: boolean, ...},
+    operatorMappings: {methodName: boolean, ...},
+    operatorDefinitions: {methodName: boolean, ...},
+    filters: {methodName: boolean, ...}
+}
+```
+methods for each category mentioned above can be seen defined here: 
+https://www.w3.org/TR/rdf-sparql-query/
+
+#### Standarised Errors
+
+In the case of issuing a SPARQL query when the methods is not supported as denoted in the interface above, we may want to issue an error saying so. That could be done by extending the existing `ExceptionType` error on AD4M to also include variant: `UnsupportedSPARQLMethod`
+
+---
+
+## Exciting Possibilities
+
+- We would have a path to create linkLanguages over holochain which would make holochain a general, distributed database with abilities to encode complex validation/complex rules.
+- Tools such as: https://sparnatural.eu/ could be used out of the box to explore perspectivedat
+- SPARQL allows the wrapping of RDF databases in HTTP methods, which would enable the creation of LinkLanguages which can bridge existing RDF databases (wikipedia etc) into the AD4M ecosystem. See:
+
+![](https://i.imgur.com/wrhkmH7.png)
+


### PR DESCRIPTION
# PIP-3: Advanced querying and updates on LinkLanguages

## Scope
This PIP aims to create a spec allowing LinkLanguages to signal mutation, and querying of link data via SPARQL methods, with varying levels of compliance with SPARQL abilities.

## Why
Currently when querying Perspectives/Neighbourhoods its only possible to query via; source, target, predicate with optional to/from date's for filtering. This allows querying at one dimension but does not allow for advanced querying, where you may wish to do something such as getLinks and then load adjacent links associated to found triples to load large data feeds. At Flux, we have already ran into this limitation and have to issue multiple queries to fetch, emojis & replies for each chat link. 

## Useful Resources

SPARQL in 11 minutes: https://www.youtube.com/watch?v=FvGndkpa4K0
SPARQL cheatsheet: https://www.iro.umontreal.ca/~lapalme/ift6281/sparql-1_1-cheat-sheet.pdf
Constructing SPARQL Queries: https://medium.com/wallscope/constructing-sparql-queries-ca63b8b9ac02

---

## Implementation

All proposed changes here are to be made on the LinkLanguage Language interface.

### Mutation Operation Changes
##### Keep:
```
addLink(...)
updateLink(...)
removeLink(...)
```

but make optional. So that there is always a simple interface for mutation if a user does not want to use SPARQL?

##### Add:

```
mutate(command: string)
```

where command is a SPARQL query string (encoded) making the following possible operations

```
# REQUIRED SUPPORTED BY LANGUAGE:
INSERT DATA { triples }
DELETE DATA { triples }

# OPTIONALLY SUPPORTED BY LANGUAGE:
[ DELETE { template } ] [ INSERT { template } ] WHERE { pattern }
LOAD <uri> [ INTO GRAPH <uri> ]
CLEAR GRAPH <uri>
CREATAE GRAPH <uri>
DROP GRAPH <uri>
```

Note that the above operations also make it possible to insert/delete multiple triples at once, this could make it easy to mass insert data for creating archives of existing data or loading data for testing.

### Query Changes

##### Keep:

`getLinks()` but make optional. So that there is always a simple interface for querying if desired?

##### Add:
```
queryLinks(query: string): Promise<Expression[]>;
```

where command is a SPARQL query string (encoded). It would be expected that the LinkLangauge being queried would be able to respond to any valid SPARQL query where methods used are denoted as supported (see below).

##### SPARQL Literal Support

SPARQL triple values makes uses of literals to denote types, see:

![](https://i.imgur.com/YkjEGdu.png)

Since a `LinkExpression` in AD4M are supposed to reference expression URI's, we may want some kind of mapping between AD4M expression URI's & SPARQL literals, for example: `xsd://integer#3`. Which when resolved in AD4M would return the specification for xsd://integer (likely scrapped from the xsd specification). LinkLanguage storage backends could still leverage existing SPARQL literal structures for performance optimization, but then apply the AD4M formatting once results are retreived and before being returned to language caller.

---

### Optional Additions

The following are some things that came up whilst thinking about this PIP, but may not be directly necassary now, but atleast worth talking about.

#### SPARQL query ability signaling
Add interface which can return supported SPARQL "methods", looking like:

```
supportedMethods(): SPARQLMethods

interface SPARQLMethods {
    modifiers: {methodName: boolean, ...},
    queryForms: {methodName: boolean, ...},
    filterEvaluations: {methodName: boolean, ...},
    operatorMappings: {methodName: boolean, ...},
    operatorDefinitions: {methodName: boolean, ...},
    filters: {methodName: boolean, ...}
}
```
methods for each category mentioned above can be seen defined here: 
https://www.w3.org/TR/rdf-sparql-query/

#### Standarised Errors

In the case of issuing a SPARQL query when the methods is not supported as denoted in the interface above, we may want to issue an error saying so. That could be done by extending the existing `ExceptionType` error on AD4M to also include variant: `UnsupportedSPARQLMethod`

---

## Exciting Possibilities

- We would have a path to create linkLanguages over holochain which would make holochain a general, distributed database with abilities to encode complex validation/complex rules.
- Tools such as: https://sparnatural.eu/ could be used out of the box to explore perspectivedat
- SPARQL allows the wrapping of RDF databases in HTTP methods, which would enable the creation of LinkLanguages which can bridge existing RDF databases (wikipedia etc) into the AD4M ecosystem. See:

![](https://i.imgur.com/wrhkmH7.png)

